### PR TITLE
feat(claude): adopt documented settings and add skills sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
   - `settings.json` - User-level Claude Code settings with permissions and statusLine (copied to ~/.claude/settings.json)
   - `README.md` - Documentation for Claude Code configuration
   - `commands/` - Custom slash commands directory (empty, add your own)
+  - `skills/` - User-authored skills, grouped by category (e.g., `general/`, `engineering/`); setup.sh flattens to `~/.claude/skills/<skill>/SKILL.md` on sync
 
 ### Top-Level Files
 - `Brewfile` - Homebrew package manifest (not synced to $HOME, used by setup.sh)

--- a/claude/README.md
+++ b/claude/README.md
@@ -3,7 +3,7 @@
 This directory contains Claude Code configuration files that are synced to `~/.claude/` by the `setup.sh` script.
 
 **Created:** 2025-10-01
-**Last Modified:** 2026-03-24
+**Last Modified:** 2026-05-20
 
 ## Files
 
@@ -23,15 +23,26 @@ This file is copied to `~/.claude/CLAUDE.md` and applies to all Claude Code sess
 Global user-level settings for Claude Code. Includes:
 
 #### Effort Level
-`effortLevel` is set to `"max"` for deepest reasoning on Opus 4.6. Other values: `"low"`, `"medium"`, `"high"`, `"auto"`.
+`effortLevel` is set to `"xhigh"` for deepest persistent reasoning. Valid values per the docs: `"low"`, `"medium"`, `"high"`, `"xhigh"`. The session-only `/effort max` command is *not* a valid settings value — it gets silently dropped if used in JSON. See https://code.claude.com/docs/en/settings.
+
+#### Auto Updates
+`autoUpdatesChannel` is set to `"stable"` to pin to the stable release channel (~1 week behind `"latest"`) for fewer surprise regressions. There is no documented `autoUpdates: false` toggle — `autoUpdatesChannel` is the only update control.
+
+#### MCP Servers
+`enableAllProjectMcpServers` is set to `false` explicitly. This blocks any project's `.mcp.json` from auto-activating MCP servers without manual approval. Pair with `enabledMcpjsonServers` / `disabledMcpjsonServers` arrays for fine-grained control.
 
 #### Permissions
+- **defaultMode**: `"acceptEdits"` — auto-accepts `Read`/`Write`/`Edit` tool calls without prompting. Bash and other risky tools still prompt. Valid values: `"default"`, `"acceptEdits"`, `"plan"`, `"auto"`, `"dontAsk"`, `"bypassPermissions"`.
+
+- **additionalDirectories**: `["~/.claude/"]` — lets Claude read your memory, plans, transcripts, and shell snapshots cross-session without per-prompt approval.
+
 - **allow**: Commands that Claude can execute without asking for approval
   - Package manager commands (npm, pnpm, yarn lint/test/build/typecheck)
-  - GitHub CLI read commands (pr, issue, repo, run operations)
-  - Read-only git commands (status, log, diff, show, branch, remote, tag -l, stash list)
+  - GitHub CLI read commands (pr, issue, repo, run operations, `gh api`)
+  - Read-only git commands (status, log, diff, show, branch, remote, tag -l, stash list, fetch, ls-files, rev-parse)
   - Read-only Homebrew commands (list, info, search, config, doctor)
-  - Shell utilities (ls, diff, wc, which, jq)
+  - Read-only `mise` commands (current, ls, which)
+  - Shell utilities (ls, diff, wc, which, jq, rg)
   - Version checks (python, node, npm)
   - Docker read operations (ps, images, logs)
   - WebFetch for documentation sites (anthropic, github, stackoverflow, MDN)
@@ -48,10 +59,22 @@ Global user-level settings for Claude Code. Includes:
 - **SessionStart (compact)**: Re-injects key reminders after auto-compaction to prevent Claude from forgetting preferences in long conversations
 
 #### Plugins
-Enabled plugins from the official marketplace:
-- **GitHub** — PR reviews, issue management, repo operations (requires `GITHUB_PERSONAL_ACCESS_TOKEN`)
-- **Linear** — issue tracking, project management (uses OAuth)
-- **Playwright** — browser automation, testing, screenshots
+All entries reference the `claude-plugins-official` marketplace.
+
+Enabled:
+- **context7** — fetch up-to-date library/framework documentation
+- **frontend-design** — production-grade frontend component generation
+- **linear** — Linear issue tracking and project management (OAuth)
+- **playwright** — browser automation, testing, screenshots
+- **typescript-lsp** — TypeScript language server integration
+- **feature-dev** — guided feature development with codebase understanding
+- **commit-commands** — git commit/push/PR helpers
+- **terraform** — Terraform registry lookups and HCP workspace tools
+- **elixir-ls-lsp** — Elixir language server integration
+
+Explicitly disabled (kept in file for documentation):
+- **vercel** — Vercel deploy / project management
+- **posthog** — PostHog analytics integration
 
 #### Status Line
 Custom status line displaying model name and context window usage:
@@ -62,7 +85,7 @@ Custom status line displaying model name and context window usage:
 The `env` object can be used to set environment variables for Claude Code sessions.
 
 #### Co-authorship
-`attribution.commit` and `attribution.pr` control commit/PR attribution templates.
+`attribution.commit` and `attribution.pr` control commit/PR attribution templates. Both are empty strings here to suppress the `Co-Authored-By: Claude` trailer in commits and PR descriptions. The older `includeCoAuthoredBy` boolean is deprecated in current docs — use `attribution` instead.
 
 ### Project-Specific Settings
 You can create `.claude/settings.local.json` in any project directory to override global settings:

--- a/claude/README.md
+++ b/claude/README.md
@@ -137,11 +137,18 @@ description: One-line summary Claude uses to decide when this skill applies. Be 
 Instructions for Claude go here as plain Markdown.
 ```
 
-Sample skills in this repo:
-- `skills/general/branch-status/SKILL.md` — summarizes the current git branch state
-- `skills/engineering/pre-commit-check/SKILL.md` — runs lint/typecheck/test/build as a pre-commit gate
+Skills currently in this repo:
 
-Copy either directory into a category folder to start a new skill. Pick the category that fits, then rename the skill folder.
+**general/**
+- `grill-me` — interview-style stress-test of a plan; walks the decision tree, recommends answers
+- `handoff` — write a handoff document so a fresh agent can pick up the current conversation
+
+**engineering/**
+- `pre-commit-check` — run lint/typecheck/test/build as a pre-commit gate (auto-detects package manager)
+- `grill-with-docs` — `grill-me` plus inline `CONTEXT.md` and ADR updates as decisions crystallize (includes `ADR-FORMAT.md` and `CONTEXT-FORMAT.md` supporting files)
+- `to-prd` — synthesize a PRD from current conversation and publish to Linear (`disable-model-invocation: true` — must invoke explicitly with `/to-prd`)
+
+To start a new skill, copy any of the above into the category folder that fits, then rename the directory and edit the frontmatter.
 
 ## Directory Structure
 
@@ -151,13 +158,17 @@ claude/
 ├── CLAUDE.md         # Global instructions for Claude Code
 ├── settings.json     # Global user settings
 ├── commands/         # Custom slash commands (add your own)
-└── skills/           # User-authored skills, grouped by category
+└── skills/                       # User-authored skills, grouped by category
     ├── general/
-    │   └── branch-status/
-    │       └── SKILL.md
+    │   ├── grill-me/SKILL.md
+    │   └── handoff/SKILL.md
     └── engineering/
-        └── pre-commit-check/
-            └── SKILL.md
+        ├── pre-commit-check/SKILL.md
+        ├── grill-with-docs/
+        │   ├── SKILL.md
+        │   ├── ADR-FORMAT.md
+        │   └── CONTEXT-FORMAT.md
+        └── to-prd/SKILL.md
 ```
 
 ## Usage

--- a/claude/README.md
+++ b/claude/README.md
@@ -101,6 +101,48 @@ You can create `.claude/settings.local.json` in any project directory to overrid
 
 Settings are merged with global settings (project settings take precedence). Add to `.gitignore` to avoid committing local preferences.
 
+### `skills/`
+User-authored skills, organized in the repo by category but **flattened on sync** to `~/.claude/skills/<skill>/SKILL.md`. Claude Code only discovers skills one level deep, so categories exist purely for repo organization — `setup.sh` strips the category folder when copying.
+
+Repo layout:
+```
+skills/
+├── general/
+│   └── branch-status/SKILL.md
+└── engineering/
+    └── pre-commit-check/SKILL.md
+```
+
+After `./setup.sh` runs:
+```
+~/.claude/skills/
+├── branch-status/SKILL.md
+└── pre-commit-check/SKILL.md
+```
+
+**Rules enforced by setup.sh:**
+- Every SKILL.md must live inside a category folder (no `skills/<skill>/SKILL.md` at the top level — setup will bail).
+- Skill names must be unique across categories (no two categories can both define `branch-status` — setup will bail).
+
+A skill is a packaged set of instructions Claude can invoke — automatically (when a request matches the skill's `description` frontmatter) or manually via `/<skill-name>` (unless `disable-model-invocation: true` is set). See https://code.claude.com/docs/en/skills for the full authoring guide.
+
+**Minimum SKILL.md shape:**
+```markdown
+---
+description: One-line summary Claude uses to decide when this skill applies. Be specific about triggers.
+---
+
+# my-skill
+
+Instructions for Claude go here as plain Markdown.
+```
+
+Sample skills in this repo:
+- `skills/general/branch-status/SKILL.md` — summarizes the current git branch state
+- `skills/engineering/pre-commit-check/SKILL.md` — runs lint/typecheck/test/build as a pre-commit gate
+
+Copy either directory into a category folder to start a new skill. Pick the category that fits, then rename the skill folder.
+
 ## Directory Structure
 
 ```
@@ -108,7 +150,14 @@ claude/
 ├── README.md         # This file
 ├── CLAUDE.md         # Global instructions for Claude Code
 ├── settings.json     # Global user settings
-└── commands/         # Custom slash commands (add your own)
+├── commands/         # Custom slash commands (add your own)
+└── skills/           # User-authored skills, grouped by category
+    ├── general/
+    │   └── branch-status/
+    │       └── SKILL.md
+    └── engineering/
+        └── pre-commit-check/
+            └── SKILL.md
 ```
 
 ## Usage

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,12 +1,18 @@
 {
   "env": {},
-  "effortLevel": "high",
+  "effortLevel": "xhigh",
   "cleanupPeriodDays": 90,
+  "autoUpdatesChannel": "stable",
+  "enableAllProjectMcpServers": false,
   "attribution": {
     "commit": "",
     "pr": ""
   },
   "permissions": {
+    "defaultMode": "acceptEdits",
+    "additionalDirectories": [
+      "~/.claude/"
+    ],
     "allow": [
       "Bash(npm run lint)",
       "Bash(npm run test)",
@@ -44,6 +50,14 @@
       "Bash(git remote:*)",
       "Bash(git tag -l:*)",
       "Bash(git stash list:*)",
+      "Bash(git fetch:*)",
+      "Bash(git ls-files:*)",
+      "Bash(git rev-parse:*)",
+      "Bash(gh api:*)",
+      "Bash(mise current)",
+      "Bash(mise ls)",
+      "Bash(mise which:*)",
+      "Bash(rg:*)",
       "Bash(brew list:*)",
       "Bash(brew info:*)",
       "Bash(brew search:*)",
@@ -106,7 +120,14 @@
     "context7@claude-plugins-official": true,
     "frontend-design@claude-plugins-official": true,
     "linear@claude-plugins-official": true,
-    "playwright@claude-plugins-official": true
+    "playwright@claude-plugins-official": true,
+    "typescript-lsp@claude-plugins-official": true,
+    "feature-dev@claude-plugins-official": true,
+    "commit-commands@claude-plugins-official": true,
+    "terraform@claude-plugins-official": true,
+    "elixir-ls-lsp@claude-plugins-official": true,
+    "vercel@claude-plugins-official": false,
+    "posthog@claude-plugins-official": false
   },
   "statusLine": {
     "type": "command",

--- a/claude/skills/engineering/grill-with-docs/ADR-FORMAT.md
+++ b/claude/skills/engineering/grill-with-docs/ADR-FORMAT.md
@@ -1,0 +1,47 @@
+# ADR Format
+
+ADRs live in `docs/adr/` and use sequential numbering: `0001-slug.md`, `0002-slug.md`, etc.
+
+Create the `docs/adr/` directory lazily — only when the first ADR is needed.
+
+## Template
+
+```md
+# {Short title of the decision}
+
+{1-3 sentences: what's the context, what did we decide, and why.}
+```
+
+That's it. An ADR can be a single paragraph. The value is in recording _that_ a decision was made and _why_ — not in filling out sections.
+
+## Optional sections
+
+Only include these when they add genuine value. Most ADRs won't need them.
+
+- **Status** frontmatter (`proposed | accepted | deprecated | superseded by ADR-NNNN`) — useful when decisions are revisited
+- **Considered Options** — only when the rejected alternatives are worth remembering
+- **Consequences** — only when non-obvious downstream effects need to be called out
+
+## Numbering
+
+Scan `docs/adr/` for the highest existing number and increment by one.
+
+## When to offer an ADR
+
+All three of these must be true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will look at the code and wonder "why on earth did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If a decision is easy to reverse, skip it — you'll just reverse it. If it's not surprising, nobody will wonder why. If there was no real alternative, there's nothing to record beyond "we did the obvious thing."
+
+### What qualifies
+
+- **Architectural shape.** "We're using a monorepo." "The write model is event-sourced, the read model is projected into Postgres."
+- **Integration patterns between contexts.** "Ordering and Billing communicate via domain events, not synchronous HTTP."
+- **Technology choices that carry lock-in.** Database, message bus, auth provider, deployment target. Not every library — just the ones that would take a quarter to swap out.
+- **Boundary and scope decisions.** "Customer data is owned by the Customer context; other contexts reference it by ID only." The explicit no-s are as valuable as the yes-s.
+- **Deliberate deviations from the obvious path.** "We're using manual SQL instead of an ORM because X." Anything where a reasonable reader would assume the opposite. These stop the next engineer from "fixing" something that was deliberate.
+- **Constraints not visible in the code.** "We can't use AWS because of compliance requirements." "Response times must be under 200ms because of the partner API contract."
+- **Rejected alternatives when the rejection is non-obvious.** If you considered GraphQL and picked REST for subtle reasons, record it — otherwise someone will suggest GraphQL again in six months.

--- a/claude/skills/engineering/grill-with-docs/CONTEXT-FORMAT.md
+++ b/claude/skills/engineering/grill-with-docs/CONTEXT-FORMAT.md
@@ -1,0 +1,63 @@
+# CONTEXT.md Format
+
+## Structure
+
+```md
+# {Context Name}
+
+{One or two sentence description of what this context is and why it exists.}
+
+## Language
+
+**Order**:
+{A one or two sentence description of the term}
+_Avoid_: Purchase, transaction
+
+**Invoice**:
+A request for payment sent to a customer after delivery.
+_Avoid_: Bill, payment request
+
+**Customer**:
+A person or organization that places orders.
+_Avoid_: Client, buyer, account
+```
+
+## Rules
+
+- **Be opinionated.** When multiple words exist for the same concept, pick the best one and list the others as aliases to avoid.
+- **Flag conflicts explicitly.** If a term is used ambiguously, call it out in "Flagged ambiguities" with a clear resolution.
+- **Keep definitions tight.** One or two sentences max. Define what it IS, not what it does.
+- **Show relationships.** Use bold term names and express cardinality where obvious.
+- **Only include terms specific to this project's context.** General programming concepts (timeouts, error types, utility patterns) don't belong even if the project uses them extensively. Before adding a term, ask: is this a concept unique to this context, or a general programming concept? Only the former belongs.
+- **Group terms under subheadings** when natural clusters emerge. If all terms belong to a single cohesive area, a flat list is fine.
+- **Write an example dialogue.** A conversation between a dev and a domain expert that demonstrates how the terms interact naturally and clarifies boundaries between related concepts.
+
+## Single vs multi-context repos
+
+**Single context (most repos):** One `CONTEXT.md` at the repo root.
+
+**Multiple contexts:** A `CONTEXT-MAP.md` at the repo root lists the contexts, where they live, and how they relate to each other:
+
+```md
+# Context Map
+
+## Contexts
+
+- [Ordering](./src/ordering/CONTEXT.md) — receives and tracks customer orders
+- [Billing](./src/billing/CONTEXT.md) — generates invoices and processes payments
+- [Fulfillment](./src/fulfillment/CONTEXT.md) — manages warehouse picking and shipping
+
+## Relationships
+
+- **Ordering → Fulfillment**: Ordering emits `OrderPlaced` events; Fulfillment consumes them to start picking
+- **Fulfillment → Billing**: Fulfillment emits `ShipmentDispatched` events; Billing consumes them to generate invoices
+- **Ordering ↔ Billing**: Shared types for `CustomerId` and `Money`
+```
+
+The skill infers which structure applies:
+
+- If `CONTEXT-MAP.md` exists, read it to find contexts
+- If only a root `CONTEXT.md` exists, single context
+- If neither exists, create a root `CONTEXT.md` lazily when the first term is resolved
+
+When multiple contexts exist, infer which one the current topic relates to. If unclear, ask.

--- a/claude/skills/engineering/grill-with-docs/SKILL.md
+++ b/claude/skills/engineering/grill-with-docs/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: grill-with-docs
+description: Grilling session that challenges your plan against the existing domain model, sharpens terminology, and updates documentation (CONTEXT.md, ADRs) inline as decisions crystallise. Use when user wants to stress-test a plan against their project's language and documented decisions.
+---
+
+<what-to-do>
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time, waiting for feedback on each question before continuing.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.
+
+</what-to-do>
+
+<supporting-info>
+
+## Domain awareness
+
+During codebase exploration, also look for existing documentation:
+
+### File structure
+
+Most repos have a single context:
+
+```
+/
+├── CONTEXT.md
+├── docs/
+│   └── adr/
+│       ├── 0001-event-sourced-orders.md
+│       └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+If a `CONTEXT-MAP.md` exists at the root, the repo has multiple contexts. The map points to where each one lives:
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/
+│   └── adr/                          ← system-wide decisions
+├── src/
+│   ├── ordering/
+│   │   ├── CONTEXT.md
+│   │   └── docs/adr/                 ← context-specific decisions
+│   └── billing/
+│       ├── CONTEXT.md
+│       └── docs/adr/
+```
+
+Create files lazily — only when you have something to write. If no `CONTEXT.md` exists, create one when the first term is resolved. If no `docs/adr/` exists, create it when the first ADR is needed.
+
+## During the session
+
+### Challenge against the glossary
+
+When the user uses a term that conflicts with the existing language in `CONTEXT.md`, call it out immediately. "Your glossary defines 'cancellation' as X, but you seem to mean Y — which is it?"
+
+### Sharpen fuzzy language
+
+When the user uses vague or overloaded terms, propose a precise canonical term. "You're saying 'account' — do you mean the Customer or the User? Those are different things."
+
+### Discuss concrete scenarios
+
+When domain relationships are being discussed, stress-test them with specific scenarios. Invent scenarios that probe edge cases and force the user to be precise about the boundaries between concepts.
+
+### Cross-reference with code
+
+When the user states how something works, check whether the code agrees. If you find a contradiction, surface it: "Your code cancels entire Orders, but you just said partial cancellation is possible — which is right?"
+
+### Update CONTEXT.md inline
+
+When a term is resolved, update `CONTEXT.md` right there. Don't batch these up — capture them as they happen. Use the format in [CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md).
+
+`CONTEXT.md` should be totally devoid of implementation details. Do not treat `CONTEXT.md` as a spec, a scratch pad, or a repository for implementation decisions. It is a glossary and nothing else.
+
+### Offer ADRs sparingly
+
+Only offer to create an ADR when all three are true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will wonder "why did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If any of the three is missing, skip the ADR. Use the format in [ADR-FORMAT.md](./ADR-FORMAT.md).
+
+</supporting-info>

--- a/claude/skills/engineering/pre-commit-check/SKILL.md
+++ b/claude/skills/engineering/pre-commit-check/SKILL.md
@@ -1,0 +1,41 @@
+---
+description: Run the project's lint, type-check, test, and build commands as a pre-commit gate. Use when the user asks to verify code before committing/pushing, run all checks, or ask "is this ready?".
+---
+
+# pre-commit-check
+
+Run the project's quality gates in order and report a pass/fail summary. Stop at the first failure and show the relevant error output so the user can fix it.
+
+## Steps
+
+1. **Detect the package manager** — check lockfiles in this order:
+   - `pnpm-lock.yaml` → use `pnpm`
+   - `yarn.lock` → use `yarn`
+   - `package-lock.json` or `bun.lockb` → use `npm` or `bun` respectively
+   - none → fall through to non-JS gates below
+
+2. **Run the JS/TS gates** (in this order, skip any whose script doesn't exist in `package.json`):
+   - lint: `<pm> run lint`
+   - type-check: `<pm> run typecheck` (or `tsc --noEmit` if no script)
+   - test: `<pm> run test`
+   - build: `<pm> run build`
+
+3. **Non-JS fallbacks** (run if applicable, skip otherwise):
+   - `Makefile` with a `check` target → `make check`
+   - `justfile` with a `check` recipe → `just check`
+   - `Cargo.toml` → `cargo check && cargo test`
+   - `go.mod` → `go vet ./... && go test ./...`
+
+4. **Report**: one line per step with ✅ / ❌. On the first failure, print the last 20 lines of stderr and stop.
+
+## Output shape
+
+```
+pre-commit-check (<package-manager or "make"/etc>)
+  ✅ lint
+  ✅ typecheck
+  ❌ test
+     <last 20 lines of failure output>
+```
+
+If everything passes, end with `Ready to commit.`

--- a/claude/skills/engineering/to-prd/SKILL.md
+++ b/claude/skills/engineering/to-prd/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: to-prd
+description: Turn the current conversation context into a PRD and publish it to the project issue tracker. Use when user wants to create a PRD from the current context.
+disable-model-invocation: true
+---
+
+This skill takes the current conversation context and codebase understanding and produces a PRD. Do NOT interview the user about the PRD content — just synthesize what you already know.
+
+Publish to Linear via the linear plugin. If the user hasn't told you which team or project, ask before creating the issue. Apply any relevant labels that already exist on the team — don't invent new ones unless the user asks.
+
+## Process
+
+1. Explore the repo to understand the current state of the codebase, if you haven't already. Use the project's domain glossary vocabulary throughout the PRD, and respect any ADRs in the area you're touching.
+
+2. Sketch out the major modules you will need to build or modify to complete the implementation. Actively look for opportunities to extract deep modules that can be tested in isolation.
+
+A deep module (as opposed to a shallow module) is one which encapsulates a lot of functionality in a simple, testable interface which rarely changes.
+
+Check with the user that these modules match their expectations. Check with the user which modules they want tests written for.
+
+3. Write the PRD using the template below, then publish it to Linear.
+
+<prd-template>
+
+## Problem Statement
+
+The problem that the user is facing, from the user's perspective.
+
+## Solution
+
+The solution to the problem, from the user's perspective.
+
+## User Stories
+
+A LONG, numbered list of user stories. Each user story should be in the format of:
+
+1. As an <actor>, I want a <feature>, so that <benefit>
+
+<user-story-example>
+1. As a mobile bank customer, I want to see balance on my accounts, so that I can make better informed decisions about my spending
+</user-story-example>
+
+This list of user stories should be extremely extensive and cover all aspects of the feature.
+
+## Implementation Decisions
+
+A list of implementation decisions that were made. This can include:
+
+- The modules that will be built/modified
+- The interfaces of those modules that will be modified
+- Technical clarifications from the developer
+- Architectural decisions
+- Schema changes
+- API contracts
+- Specific interactions
+
+Do NOT include specific file paths or code snippets. They may end up being outdated very quickly.
+
+Exception: if a prototype produced a snippet that encodes a decision more precisely than prose can (state machine, reducer, schema, type shape), inline it within the relevant decision and note briefly that it came from a prototype. Trim to the decision-rich parts — not a working demo, just the important bits.
+
+## Testing Decisions
+
+A list of testing decisions that were made. Include:
+
+- A description of what makes a good test (only test external behavior, not implementation details)
+- Which modules will be tested
+- Prior art for the tests (i.e. similar types of tests in the codebase)
+
+## Out of Scope
+
+A description of the things that are out of scope for this PRD.
+
+## Further Notes
+
+Any further notes about the feature.
+
+</prd-template>

--- a/claude/skills/general/grill-me/SKILL.md
+++ b/claude/skills/general/grill-me/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: grill-me
+description: Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions "grill me".
+---
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.

--- a/claude/skills/general/handoff/SKILL.md
+++ b/claude/skills/general/handoff/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: handoff
+description: Compact the current conversation into a handoff document for another agent to pick up.
+argument-hint: "What will the next session be used for?"
+---
+
+Write a handoff document summarising the current conversation so a fresh agent can continue the work. Save to the temporary directory of the user's OS - not the current workspace.
+
+Include a "suggested skills" section in the document, which suggests skills that the agent should invoke.
+
+Do not duplicate content already captured in other artifacts (PRDs, plans, ADRs, issues, commits, diffs). Reference them by path or URL instead.
+
+Redact any sensitive information, such as API keys, passwords, or personally identifiable information.
+
+If the user passed arguments, treat them as a description of what the next session will focus on and tailor the doc accordingly.

--- a/setup.sh
+++ b/setup.sh
@@ -85,7 +85,42 @@ rsync -avq --no-perms --backup --backup-dir="$backup_directory/git" git/ "$HOME"
 
 echo "🤖 Setting up Claude configuration..."
 mkdir -p "$HOME/.claude" || { echo "❌ Failed to create .claude directory. Check permissions?"; exit 1; }
-rsync -avq --no-perms --backup --backup-dir="$backup_directory/claude" claude/ "$HOME/.claude" || { echo "❌ Claude configuration sync failed. Check permissions?"; exit 1; }
+
+# Sync everything except skills/ — skills are organized into category folders
+# in the repo (claude/skills/<category>/<skill>/SKILL.md) but Claude Code
+# expects them flat (~/.claude/skills/<skill>/SKILL.md), so they need a
+# separate flattening pass below.
+rsync -avq --no-perms --backup --backup-dir="$backup_directory/claude" \
+  --exclude='skills' \
+  claude/ "$HOME/.claude" || { echo "❌ Claude configuration sync failed. Check permissions?"; exit 1; }
+
+# Flatten skills: claude/skills/<category>/<skill>/ → ~/.claude/skills/<skill>/
+if [ -d "claude/skills" ]; then
+  # Bail if any SKILL.md is sitting flat (not inside a category folder)
+  loose_skills="$(find claude/skills -mindepth 2 -maxdepth 2 -name SKILL.md 2>/dev/null)"
+  if [ -n "$loose_skills" ]; then
+    echo "❌ Found SKILL.md files outside a category folder:"
+    echo "$loose_skills" | sed 's/^/   /'
+    echo "   Move each into claude/skills/<category>/<skill-name>/SKILL.md"
+    exit 1
+  fi
+
+  # Bail if two categories define the same skill name (would silently clobber)
+  duplicates="$(find claude/skills -mindepth 2 -maxdepth 2 -type d 2>/dev/null | xargs -n1 basename 2>/dev/null | sort | uniq -d)"
+  if [ -n "$duplicates" ]; then
+    echo "❌ Duplicate skill names across categories:"
+    echo "$duplicates" | sed 's/^/   - /'
+    echo "   Each skill name must be unique across all category folders."
+    exit 1
+  fi
+
+  mkdir -p "$HOME/.claude/skills"
+  for category_dir in claude/skills/*/; do
+    [ -d "$category_dir" ] || continue
+    rsync -avq --no-perms --backup --backup-dir="$backup_directory/claude/skills" \
+      "$category_dir" "$HOME/.claude/skills/" || { echo "❌ Skills sync failed. Check permissions?"; exit 1; }
+  done
+fi
 
 # Return to the original directory
 cd "$current_directory" || { echo "❌ Couldn't return to where you started."; exit 1; }

--- a/shell/.bash_profile
+++ b/shell/.bash_profile
@@ -17,6 +17,14 @@ export PATH="$HOME/bin:$PATH"
 ## Add user local bin directory to path
 export PATH="$HOME/.local/bin:$PATH"
 
+## Google Cloud SDK (gcloud, bq, gsutil, etc.)
+if [ -d "/opt/homebrew/share/google-cloud-sdk/bin" ]; then
+  export PATH="/opt/homebrew/share/google-cloud-sdk/bin:$PATH"
+fi
+if [ -f "/opt/homebrew/share/google-cloud-sdk/completion.bash.inc" ]; then
+  source "/opt/homebrew/share/google-cloud-sdk/completion.bash.inc"
+fi
+
 ## Colorized Output
 export CLICOLOR=1
 

--- a/shell/.zshrc
+++ b/shell/.zshrc
@@ -104,6 +104,18 @@ if [ -d "/opt/homebrew/opt/libpq/bin" ]; then
   esac
 fi
 
+## Google Cloud SDK (gcloud, bq, gsutil, etc.)
+if [ -d "/opt/homebrew/share/google-cloud-sdk/bin" ]; then
+  case ":$PATH:" in
+    *":/opt/homebrew/share/google-cloud-sdk/bin:"*) ;;
+    *) export PATH="/opt/homebrew/share/google-cloud-sdk/bin:$PATH" ;;
+  esac
+fi
+### gcloud shell completion
+if [ -f "/opt/homebrew/share/google-cloud-sdk/completion.zsh.inc" ]; then
+  source "/opt/homebrew/share/google-cloud-sdk/completion.zsh.inc"
+fi
+
 # Machine-specific overrides (not tracked in dotfiles)
 [[ -f ~/.zshrc.local ]] && source ~/.zshrc.local
 


### PR DESCRIPTION
## Summary

- **Settings audit** against current Claude Code docs (https://code.claude.com/docs/en/settings):
  - Adopted `permissions.defaultMode: "acceptEdits"`, `permissions.additionalDirectories: ["~/.claude/"]`, `enableAllProjectMcpServers: false`, `autoUpdatesChannel: "stable"`
  - Expanded `permissions.allow` with read-only git/gh/mise/rg commands
  - Fixed `effortLevel: "max"` (invalid, silently dropped) → `"xhigh"` (deepest documented value)
  - Captured plugin drift: 6 plugins already enabled in `~/.claude/settings.json` are now in the synced repo, plus 2 explicit-off (`vercel`, `posthog`)

- **New skills sync mechanism**: `setup.sh` now flattens `claude/skills/<category>/<skill>/` → `~/.claude/skills/<skill>/`, with guards against loose `SKILL.md` files and duplicate skill names across categories

- **Seeded 5 personal skills**: `grill-me`, `handoff`, `pre-commit-check`, `grill-with-docs`, `to-prd` (the last one marked `disable-model-invocation: true` since it publishes to Linear)

- **Documentation**: `claude/README.md` and top-level `CLAUDE.md` updated to describe the new skills layout and document the audited settings; clarified that `includeCoAuthoredBy` is deprecated in favor of `attribution`

## Test Plan

- Run `./setup.sh` and confirm it completes without errors
- In a fresh Claude Code session, run `/config` and verify the new keys are active (`defaultMode`, `additionalDirectories`, `autoUpdatesChannel`, `effortLevel: "xhigh"`)
- Confirm the seeded skills appear in `/` — try invoking `/grill-me`, `/handoff`, `/pre-commit-check`
- Verify `/to-prd` is NOT auto-suggested when conversation drifts toward "we should document this" — it should require explicit `/to-prd` invocation
- (Optional) drop a loose `SKILL.md` outside a category, or duplicate a skill name across categories, and re-run `./setup.sh` to confirm it bails with a clear error message