### PR TITLE
fix(git): drop tag-prune and multi-remote fetch defaults

### DIFF
--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -37,9 +37,6 @@
   # Delete local branches whose remotes are gone (after PR merge)
   gone = !git fetch -p && git branch -vv | grep \": gone]\" | awk '{print $1}' | xargs -r git branch -D
 
-  # Pull with force-updated tags (use instead of `git pull` when tags are moved on remote)
-  p = !git fetch origin --force --prune --prune-tags '+refs/tags/*:refs/tags/*' && git merge @{upstream}
-
 [color]
   # Enable color in Git output when possible
   ui = auto
@@ -70,14 +67,6 @@
   # Automatically prune deleted remote branches when fetching
   # Keeps your remote tracking branches clean
   prune = true
-
-  # Also prune tags that no longer exist on the remote
-  # Keeps your tags in sync with remote repository
-  pruneTags = true
-
-  # Fetch from all remotes when running git fetch
-  # Ensures you have the latest state from all remotes
-  all = true
 
 [rebase]
   # Automatically handle commits with fixup! or squash!

--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -17,6 +17,8 @@
   b = branch
   c = commit
   co = checkout
+  sw = switch    # Modern, branch-only counterpart to checkout
+  re = restore   # Modern, file-only counterpart to checkout
   st = status -s # Short status with branch information
 
   # Pretty log format with colors and concise information - reverse order (newest at bottom)

--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -46,6 +46,9 @@
   # Improves readability of commands like git branch
   ui = auto
 
+  # Always format `git branch` output in columns
+  branch = always
+
 [push]
   # Push only the current branch to the upstream branch
   default = simple
@@ -80,6 +83,10 @@
   # Update refs that would be pushed during interactive rebase
   updateRefs = true
 
+  # Refuse an interactive rebase that would silently drop commits
+  # (e.g. you accidentally delete a `pick` line)
+  missingCommitsCheck = error
+
 [diff]
   # Use histogram algorithm for better diffs
   # An improved version of patience algorithm that's faster and handles some edge cases better
@@ -89,6 +96,9 @@
   # Makes it easier to see code that was relocated rather than changed
   colorMoved = plain
 
+  # Still treat reindented blocks as moves, not as new code
+  colorMovedWS = allow-indentation-change
+
   # Use a/b/c instead of old/new in diff output
   # Makes it easier to remember which side is which
   mnemonicPrefix = true
@@ -96,6 +106,20 @@
   # Detect renamed files in diffs
   # Shows files as renamed rather than as deleted and added
   renames = true
+
+[merge]
+  # Show the common ancestor in conflict markers, not just the two sides
+  # Dramatically reduces "what was I supposed to do here" moments
+  conflictStyle = zdiff3
+
+[transfer]
+  # Check object integrity on every fetch, push, and receive
+  # Catches the (rare) corrupted transfer before it lands in your repo
+  fsckObjects = true
+
+[log]
+  # Friendlier default timestamps (`2 hours ago`, `Tue 14:03`)
+  date = human
 
 [help]
   # Prompt before automatically running mistyped commands


### PR DESCRIPTION
## Summary

Plain `git pull` was rejecting in repos that use moving deploy tags (a tag like `prod` or `release` force-moved by CI on each deploy). The `p` alias worked around the rejection, but came with a `--prune-tags` time bomb. It would silently delete the local tag after CI removed it from the remote, which broke any local script that compared `<tag>..HEAD` (e.g. a deploy Makefile that previews `git log prod..HEAD`).

Drop three globally-applied settings that together caused the problem:

- `alias.p` — the pull-with-force-tags workaround. No longer needed.
- `fetch.pruneTags = true` — silently deleted local tags whenever they disappeared from the remote.
- `fetch.all = true` — fetched from every remote on every fetch, amplifying the above when multiple remotes are present.

`fetch.prune = true` (branch pruning) stays. That's safe and useful.

## Why these are sane defaults

The dot-files assume the common case: tags are immutable. With these three removed, plain `git pull` works silently in immutable-tag repos (the broad majority).

For repos that *do* use moving tags, the fix lives per-machine, not in dot-files. See below.

## Per-machine setup for moving-tag repos

On any machine where you work with an org/host whose repos use moving deploy tags, configure two machine-local files. These are intentionally not tracked here.

`~/.gitconfig.local` — always loaded:

```ini
[user]
  signingkey = ~/.ssh/id_ed25519.pub

[includeIf "hasconfig:remote.*.url:git@<host>:<org>/**"]
  path = ~/.gitconfig-<org>
```

`~/.gitconfig-<org>` — loaded only when the current repo has a remote matching the pattern above:

```ini
[user]
  email = you@<org>.example     # if different from your default

[remote "origin"]
  fetch = +refs/heads/*:refs/remotes/origin/*
  fetch = +refs/tags/*:refs/tags/*
```

The `+` on both refspecs makes tag updates force. A `git fetch` (and therefore `git pull`) in any matching repo silently overwrites the local tag instead of rejecting.

### Why `hasconfig` over `gitdir`

`hasconfig:remote.*.url:...` triggers on the repo's remote URL. It is portable across machines because the URL is the same regardless of where on disk you cloned the repo. The older `gitdir:<path>` discriminator only works when you put repos under a fixed local path. Requires git 2.36+.

### Why a separate `~/.gitconfig-<org>` file at all

`includeIf` only accepts a `path =` include. The conditional content has to live in its own file. `~/.gitconfig.local` holds the always-loaded local settings (signing key, the `includeIf` itself). `~/.gitconfig-<org>` holds the conditionally-loaded ones (org email, per-remote force refspecs).

## Test Plan

- [ ] In a repo with immutable tags, `git pull` works silently.
- [ ] In a repo with a moving deploy tag, after applying the per-machine override, `git pull` works silently (no `[rejected]` warnings).
- [ ] In a repo with a moving deploy tag, without the per-machine override, `git pull` still updates the branch but may print a `[rejected]` line for the tag.
- [ ] In a repo with a moving deploy tag, a script that does `git log <tag>..HEAD` keeps working across pulls (the local tag is no longer silently pruned).