### PR TITLE
feat(claude): switch to latest channel and auto permission mode

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -2,14 +2,14 @@
   "env": {},
   "effortLevel": "xhigh",
   "cleanupPeriodDays": 90,
-  "autoUpdatesChannel": "stable",
+  "autoUpdatesChannel": "latest",
   "enableAllProjectMcpServers": false,
   "attribution": {
     "commit": "",
     "pr": ""
   },
   "permissions": {
-    "defaultMode": "acceptEdits",
+    "defaultMode": "auto",
     "additionalDirectories": [
       "~/.claude/"
     ],


### PR DESCRIPTION
Track the latest release channel for earlier access to new models, and default to auto mode so permission prompts get classified instead of auto-accepting every edit.