### PR TITLE
feat(claude): add two-axis-review skill

### DIFF
--- a/claude/README.md
+++ b/claude/README.md
@@ -3,7 +3,7 @@
 This directory contains Claude Code configuration files that are synced to `~/.claude/` by the `setup.sh` script.
 
 **Created:** 2025-10-01
-**Last Modified:** 2026-07-08
+**Last Modified:** 2026-07-13
 
 ## Files
 
@@ -137,7 +137,7 @@ description: One-line summary Claude uses to decide when this skill applies. Be 
 Instructions for Claude go here as plain Markdown.
 ```
 
-Most skills here track [Matt Pocock's skills repo](https://github.com/mattpocock/skills) (last synced 2026-07-08), with two local adaptations: the setup skill is de-branded to `setup-skills`, and Linear is a first-class issue tracker option (`setup-skills/issue-tracker-linear.md`). `confirm-findings` and `pre-commit-check` are original to this repo. Upstream's `code-review` and `research` skills are deliberately skipped — Claude Code ships built-in `/code-review` and deep-research.
+Most skills here track [Matt Pocock's skills repo](https://github.com/mattpocock/skills) (last synced 2026-07-08), with three local adaptations: the setup skill is de-branded to `setup-skills`, Linear is a first-class issue tracker option (`setup-skills/issue-tracker-linear.md`), and upstream's `code-review` is adopted as `two-axis-review` with narrowed triggers — its upstream name shadows Claude Code's built-in `/code-review` in the CLI (see mattpocock/skills#483). `confirm-findings` and `pre-commit-check` are original to this repo. Upstream's `research` skill is deliberately skipped — Claude Code ships deep-research built in.
 
 Skills currently in this repo:
 
@@ -163,6 +163,7 @@ Skills currently in this repo:
 - `to-spec` — synthesize the conversation into a spec and publish to the configured tracker
 - `to-tickets` — break a plan/spec into tracer-bullet tickets with native blocking edges
 - `triage` — move issues (and external PRs) through a triage-role state machine
+- `two-axis-review` — review a diff on two axes: Standards (repo standards + Fowler smells) and Spec (does it match the ticket?), in parallel sub-agents
 - `wayfinder` — plan work too big for one session as a map of investigation tickets
 
 To start a new skill, copy any of the above into the category folder that fits, then rename the directory and edit the frontmatter.
@@ -183,7 +184,7 @@ claude/
         ├── codebase-design/  confirm-findings/  diagnosing-bugs/
         ├── domain-modeling/  grill-with-docs/  implement/
         ├── improve-codebase-architecture/  pre-commit-check/  prototype/
-        └── tdd/  to-spec/  to-tickets/  triage/  wayfinder/
+        └── tdd/  to-spec/  to-tickets/  triage/  two-axis-review/  wayfinder/
 ```
 
 ## Usage

--- a/claude/skills/engineering/implement/SKILL.md
+++ b/claude/skills/engineering/implement/SKILL.md
@@ -10,6 +10,6 @@ Use /tdd where possible, at pre-agreed seams.
 
 Run typechecking regularly, single test files regularly, and the full test suite once at the end.
 
-Once done, use /code-review to review the work.
+Once done, use /two-axis-review to review the work.
 
 Commit your work to the current branch.

--- a/claude/skills/engineering/tdd/SKILL.md
+++ b/claude/skills/engineering/tdd/SKILL.md
@@ -33,4 +33,4 @@ Ask: "What's the public interface, and which seams should we test?"
 
 - **Red before green.** Write the failing test first, then only enough code to pass it. Don't anticipate future tests or add speculative features.
 - **One slice at a time.** One seam, one test, one minimal implementation per cycle.
-- **Refactoring is not part of the loop.** It belongs to the review stage (see the `code-review` skill), not the red → green implementation cycle.
+- **Refactoring is not part of the loop.** It belongs to the review stage (see the `two-axis-review` skill), not the red → green implementation cycle.

--- a/claude/skills/engineering/two-axis-review/SKILL.md
+++ b/claude/skills/engineering/two-axis-review/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: two-axis-review
+description: Two-axis review of a diff since a fixed point — Standards (repo coding standards plus a Fowler smell baseline) and Spec (does the change match the originating issue/spec?), run as parallel sub-agents. Use when the user wants a standards-vs-spec review, asks to check a change against its ticket or spec, or when another skill needs the two-axis review. (Not for generic review requests — the built-in code-review covers those.)
+---
+
+Two-axis review of the diff between `HEAD` and a fixed point the user supplies:
+
+- **Standards** — does the code conform to this repo's documented coding standards?
+- **Spec** — does the code faithfully implement the originating issue / PRD / spec?
+
+Both axes run as **parallel sub-agents** so they don't pollute each other's context, then this skill aggregates their findings.
+
+The issue tracker should have been provided to you — run `/setup-skills` if `docs/agents/issue-tracker.md` is missing.
+
+## Process
+
+### 1. Pin the fixed point
+
+Whatever the user said is the fixed point — a commit SHA, branch name, tag, `main`, `HEAD~5`, etc. If they didn't specify one, ask for it.
+
+Capture the diff command once: `git diff <fixed-point>...HEAD` (three-dot, so the comparison is against the merge-base). Also note the list of commits via `git log <fixed-point>..HEAD --oneline`.
+
+Before going further, confirm the fixed point resolves (`git rev-parse <fixed-point>`) and the diff is non-empty. A bad ref or empty diff should fail here — not inside two parallel sub-agents.
+
+### 2. Identify the spec source
+
+Look for the originating spec, in this order:
+
+1. Issue references in the commit messages (`#123`, `Closes #45`, GitLab `!67`, etc.) — fetch via the workflow in `docs/agents/issue-tracker.md`.
+2. A path the user passed as an argument.
+3. A PRD/spec file under `docs/`, `specs/`, or `.scratch/` matching the branch name or feature.
+4. If nothing is found, ask the user where the spec is. If they say there isn't one, the **Spec** sub-agent will skip and report "no spec available".
+
+### 3. Identify the standards sources
+
+Anything in the repo that documents how code should be written, such as `CODING_STANDARDS.md` or `CONTRIBUTING.md`.
+
+On top of whatever the repo documents, the Standards axis always carries the **smell baseline** below — a fixed set of Fowler code smells (_Refactoring_, ch.3) that applies even when a repo documents nothing. Two rules bind it:
+
+- **The repo overrides.** A documented repo standard always wins; where it endorses something the baseline would flag, suppress the smell.
+- **Always a judgement call.** Each smell is a labelled heuristic ("possible Feature Envy"), never a hard violation — and, like any standard here, skip anything tooling already enforces.
+
+Each smell reads *what it is* → *how to fix*; match it against the diff:
+
+- **Mysterious Name** — a function, variable, or type whose name doesn't reveal what it does or holds. → rename it; if no honest name comes, the design's murky.
+- **Duplicated Code** — the same logic shape appears in more than one hunk or file in the change. → extract the shared shape, call it from both.
+- **Feature Envy** — a method that reaches into another object's data more than its own. → move the method onto the data it envies.
+- **Data Clumps** — the same few fields or params keep travelling together (a type wanting to be born). → bundle them into one type, pass that.
+- **Primitive Obsession** — a primitive or string standing in for a domain concept that deserves its own type. → give the concept its own small type.
+- **Repeated Switches** — the same `switch`/`if`-cascade on the same type recurs across the change. → replace with polymorphism, or one map both sites share.
+- **Shotgun Surgery** — one logical change forces scattered edits across many files in the diff. → gather what changes together into one module.
+- **Divergent Change** — one file or module is edited for several unrelated reasons. → split so each module changes for one reason.
+- **Speculative Generality** — abstraction, parameters, or hooks added for needs the spec doesn't have. → delete it; inline back until a real need shows.
+- **Message Chains** — long `a.b().c().d()` navigation the caller shouldn't depend on. → hide the walk behind one method on the first object.
+- **Middle Man** — a class or function that mostly just delegates onward. → cut it, call the real target direct.
+- **Refused Bequest** — a subclass or implementer that ignores or overrides most of what it inherits. → drop the inheritance, use composition.
+
+### 4. Spawn both sub-agents in parallel
+
+Send a single message with two `Agent` tool calls. Use the `general-purpose` subagent for both.
+
+**Standards sub-agent prompt** — include:
+
+- The full diff command and commit list.
+- The list of standards-source files you found in step 3, **plus the smell baseline from step 3** pasted in full — the sub-agent has no other access to it.
+- The brief: "Report — per file/hunk where relevant — (a) every place the diff violates a documented standard: cite the standard (file + the rule); and (b) any baseline smell you spot: name it and quote the hunk. Distinguish hard violations from judgement calls — documented-standard breaches can be hard, but baseline smells are always judgement calls, and a documented repo standard overrides the baseline. Skip anything tooling enforces. Under 400 words."
+
+**Spec sub-agent prompt** — include:
+
+- The diff command and commit list.
+- The path or fetched contents of the spec.
+- The brief: "Report: (a) requirements the spec asked for that are missing or partial; (b) behaviour in the diff that wasn't asked for (scope creep); (c) requirements that look implemented but where the implementation looks wrong. Quote the spec line for each finding. Under 400 words."
+
+If the spec is missing, skip the Spec sub-agent and note this in the final report.
+
+### 5. Aggregate
+
+Present the two reports under `## Standards` and `## Spec` headings, verbatim or lightly cleaned. Do **not** merge or rerank findings — the two axes are deliberately separate (see _Why two axes_).
+
+End with a one-line summary: total findings per axis, and the worst issue _within each axis_ (if any). Don't pick a single winner across axes — that's the reranking the separation exists to prevent.
+
+## Why two axes
+
+A change can pass one axis and fail the other:
+
+- Code that follows every standard but implements the wrong thing → **Standards pass, Spec fail.**
+- Code that does exactly what the issue asked but breaks the project's conventions → **Spec pass, Standards fail.**
+
+Reporting them separately stops one axis from masking the other.


### PR DESCRIPTION
## Summary

- Add `two-axis-review`: reviews a diff since a fixed point on two axes, run as parallel sub-agents. Standards checks the repo's documented coding standards plus a fixed code-smell baseline. Spec checks the change against the originating issue or spec.
- Named `two-axis-review` instead of `code-review` on purpose. A user skill named `code-review` shadows the built-in `/code-review` in the CLI and is unreachable in the desktop app. The distinct name keeps both available.
- The trigger description is narrow (standards-vs-spec, check against ticket/spec). Generic requests like "review this branch" keep routing to the built-in reviewer.
- `implement` now runs `/two-axis-review` after finishing work, so the result gets checked against the ticket. `tdd`'s review-stage pointer updated to match.
- Update `claude/README.md` skill docs.

## Test Plan

- [ ] Run `./setup.sh` and confirm `~/.claude/skills/two-axis-review/SKILL.md` exists
- [ ] In a new session, confirm both `/two-axis-review` and the built-in `/code-review` are available
- [ ] Run `/two-axis-review main` on a feature branch and confirm it produces separate Standards and Spec sections