### PR TITLE
feat: tighten Claude deny rules and warn on stale skills

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -81,6 +81,7 @@
     ],
     "deny": [
       "Bash(rm -rf:*)",
+      "Bash(rm -fr:*)",
       "Bash(sudo:*)",
       "Bash(git push --force:*)",
       "Bash(git push -f:*)",
@@ -93,14 +94,22 @@
       "Bash(dd:*)",
       "Bash(mkfs:*)",
       "Bash(chmod -R 777:*)",
-      "Read(.env)",
-      "Read(.env.*)",
+      "Read(**/.env)",
+      "Read(**/.env.*)",
       "Read(**/*.pem)",
       "Read(**/*.key)",
       "Read(**/secrets/**)",
       "Read(**/credentials.json)",
       "Read(**/.aws/**)",
-      "Read(**/.ssh/**)"
+      "Read(**/.ssh/**)",
+      "Edit(**/.env)",
+      "Edit(**/.env.*)",
+      "Edit(**/*.pem)",
+      "Edit(**/*.key)",
+      "Edit(**/secrets/**)",
+      "Edit(**/credentials.json)",
+      "Edit(**/.aws/**)",
+      "Edit(**/.ssh/**)"
     ]
   },
   "hooks": {

--- a/setup.sh
+++ b/setup.sh
@@ -125,7 +125,7 @@ restore_backup() {
 # stays the single place that knows where claude/ lands.
 sync_skills() {
   local name="$1" destination="$2"
-  local loose_skills duplicates category_dir
+  local loose_skills duplicates category_dir live_skill_dir skill_name
   [ -d "$name/skills" ] || return 0
 
   # Bail if any SKILL.md is sitting flat (not inside a category folder)
@@ -155,6 +155,17 @@ sync_skills() {
   for category_dir in "$name"/skills/*/; do
     [ -d "$category_dir" ] || continue
     sync_dir "$category_dir" "$destination/skills/" "$name/skills"
+  done
+
+  # Warn about live skills the repo doesn't know about. Sync never deletes,
+  # so renaming a skill in the repo leaves the old copy behind in
+  # <destination>/skills — and that stale copy stays model-invocable.
+  for live_skill_dir in "$destination"/skills/*/; do
+    [ -d "$live_skill_dir" ] || continue
+    skill_name="$(basename "$live_skill_dir")"
+    if ! find "$name/skills" -mindepth 2 -maxdepth 2 -type d -name "$skill_name" | grep -q .; then
+      echo "⚠️  $destination/skills/$skill_name is not in this repo (stale rename or third-party install) — consider deleting it"
+    fi
   done
 }
 


### PR DESCRIPTION
## Summary
- Mirror every `Read` deny in `claude/settings.json` with an `Edit` deny, so Claude can't modify the secret files it already can't read
- Anchor the `.env` deny patterns with `**/` so nested copies are covered, and add the `rm -fr` spelling alongside `rm -rf`
- `setup.sh` now warns when `~/.claude/skills` contains a skill the repo no longer defines. Sync never deletes, so a renamed or removed skill leaves a stale, still-invocable copy behind

## Test Plan
- Run `./setup.sh`, then rename a skill folder in `claude/skills/<category>/` and run it again. The old name should be flagged with the stale-skill warning
- In a fresh Claude Code session, ask it to read a nested `.env` (e.g. `sub/dir/.env`) and confirm the deny rule blocks it